### PR TITLE
Add ability to copy to clipboard

### DIFF
--- a/src/json-viewer.ts
+++ b/src/json-viewer.ts
@@ -146,6 +146,13 @@ export function jsonViewer(state: ExternalState, onExpandedChange: () => void): 
                 state.focusedNode = null;
             }
         });
+        li.addEventListener('copy', (event: ClipboardEvent) => {
+            if (event.clipboardData) {
+                event.clipboardData.setData("text/plain", JSON.stringify(value, null, 2));
+            }
+            event.preventDefault();
+        });
+
 
         function renderChildren() {
             let children: HTMLElement[] = [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ const json = `
 if (app) {
   const jv = ce('json-viewer', { value: json, expanded: '{"": true, "/demo": true}' }) as JsonViewerWebComponent;
   const expandedNodes = ce('pre');
-  jv.addEventListener('json-viewer:expandedChange', ({ detail }: any) => {
+  jv.addEventListener('json-viewer:expanded-change', ({ detail }: any) => {
       expandedNodes.textContent = JSON.stringify(detail.expanded, null, '  ');
   });
   app.appendChild(jv);

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -44,7 +44,7 @@ export class JsonViewerWebComponent extends HTMLElement {
             return this.appRoot.innerText = e;
         }
         const [jv, select] = jsonViewer(this.jsonViewerState, () => {
-            this.emit('expandedChange', { expanded: this.jsonViewerState.expandedNodes });
+            this.emit('expanded-change', { expanded: this.jsonViewerState.expandedNodes });
         })
         this.shadowRoot!.replaceChild(jv, this.shadowRoot!.firstElementChild!);
         if (focusedNode) {


### PR DESCRIPTION
How it works:
- click on a node to select it
- use a keyboard shortcut to copy to clipboard
- the indentation for json is currently not configurable and set to 2 spaces to match identical behaviour in chrome devtools json viewer